### PR TITLE
fix(ci): use no-op MQTT client when ENV=local

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -12,7 +12,6 @@ import (
 
 	"zensor-server/cmd/api/wire"
 	"zensor-server/cmd/config"
-	maintenanceUsecases "zensor-server/internal/maintenance/usecases"
 	"zensor-server/internal/infra/async"
 	"zensor-server/internal/infra/httpserver"
 	"zensor-server/internal/infra/mqtt"
@@ -20,6 +19,7 @@ import (
 	"zensor-server/internal/infra/pubsub"
 	"zensor-server/internal/infra/replication"
 	"zensor-server/internal/infra/replication/handlers"
+	maintenanceUsecases "zensor-server/internal/maintenance/usecases"
 
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
@@ -88,22 +88,28 @@ func main() {
 	// Initialize replication service for local environment
 	replicationService := initializeReplicationService()
 
+	env, envOK := os.LookupEnv("ENV")
+	if !envOK {
+		env = "production"
+	}
+
 	var wg sync.WaitGroup
 	ticker := time.NewTicker(30 * time.Second)
-	simpleClientOpts := mqtt.SimpleClientOpts{
-		Broker:   appConfig.MQTTClient.Broker,
-		ClientID: appConfig.MQTTClient.ClientID,
-		Username: appConfig.MQTTClient.Username,
-		Password: appConfig.MQTTClient.Password, //pragma: allowlist secret
+	var mqttClient mqtt.Client
+	if env == "local" {
+		mqttClient = mqtt.NewNoOpClient()
+	} else {
+		simpleClientOpts := mqtt.SimpleClientOpts{
+			Broker:   appConfig.MQTTClient.Broker,
+			ClientID: appConfig.MQTTClient.ClientID,
+			Username: appConfig.MQTTClient.Username,
+			Password: appConfig.MQTTClient.Password, //pragma: allowlist secret
+		}
+		mqttClient = mqtt.NewSimpleClient(simpleClientOpts)
 	}
-	mqttClient := mqtt.NewSimpleClient(simpleClientOpts)
 
 	// Use environment-aware consumer factory
 	var consumerFactory pubsub.ConsumerFactory
-	env, ok := os.LookupEnv("ENV")
-	if !ok {
-		env = "production"
-	}
 	if env == "local" {
 		consumerFactory = pubsub.NewMemoryConsumerFactory("lora-integration")
 	} else {

--- a/internal/infra/mqtt/client_test.go
+++ b/internal/infra/mqtt/client_test.go
@@ -1,6 +1,7 @@
 package mqtt_test
 
 import (
+	"context"
 	"zensor-server/internal/infra/mqtt"
 
 	paho "github.com/eclipse/paho.mqtt.golang"
@@ -36,6 +37,37 @@ var _ = ginkgo.Describe("MQTT Client", func() {
 			ginkgo.It("should properly alias Message to paho.Message", func() {
 				// This test ensures that Message is properly aliased to paho.Message
 				var _ mqtt.Message = (paho.Message)(nil)
+			})
+		})
+	})
+
+	ginkgo.Context("NewNoOpClient", func() {
+		var client mqtt.Client
+
+		ginkgo.When("used as Client", func() {
+			ginkgo.BeforeEach(func() {
+				client = mqtt.NewNoOpClient()
+			})
+
+			ginkgo.It("should subscribe without error", func() {
+				err := client.Subscribe("any/topic", 0, func(mqtt.Client, mqtt.Message) {})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+
+			ginkgo.It("should publish without error when context is active", func() {
+				err := client.Publish(context.Background(), "any/topic", map[string]string{"k": "v"})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+
+			ginkgo.It("should return context error when context is cancelled", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				err := client.Publish(ctx, "any/topic", "payload")
+				gomega.Expect(err).To(gomega.Equal(context.Canceled))
+			})
+
+			ginkgo.It("should disconnect without panic", func() {
+				client.Disconnect()
 			})
 		})
 	})

--- a/internal/infra/mqtt/noop_client.go
+++ b/internal/infra/mqtt/noop_client.go
@@ -1,0 +1,30 @@
+package mqtt
+
+import "context"
+
+// NoOpClient is a Client that does not connect to a broker. It is used when
+// ENV=local so the API process can run without TTN or other MQTT credentials.
+type NoOpClient struct{}
+
+// NewNoOpClient returns a Client that performs no network I/O.
+func NewNoOpClient() *NoOpClient {
+	return &NoOpClient{}
+}
+
+// Subscribe implements Client.
+func (c *NoOpClient) Subscribe(topic string, qos byte, callback MessageHandler) error {
+	return nil
+}
+
+// Publish implements Client.
+func (c *NoOpClient) Publish(ctx context.Context, topic string, msg any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Disconnect implements Client.
+func (c *NoOpClient) Disconnect() {}
+
+var _ Client = (*NoOpClient)(nil)


### PR DESCRIPTION
Functional tests run with ENV=local but still loaded mqtt_client pointing at
The Things Network without credentials, causing connect to fail with
'not Authorized' and panic. Local mode already uses in-memory PubSub; skip
real MQTT the same way.

Made-with: Cursor
