### PR TITLE
feat: add admin page to manage API keys

### DIFF
--- a/docs/superpowers/specs/2026-08-05-admin-api-keys-page-design.md
+++ b/docs/superpowers/specs/2026-08-05-admin-api-keys-page-design.md
@@ -1,0 +1,86 @@
+# Admin API Keys Page — Design
+
+**Date:** 2026-08-05
+**Status:** Approved
+
+## Purpose
+
+The API key authentication feature ([2026-08-03-api-key-auth-design.md](2026-08-03-api-key-auth-design.md)) shipped backend-only: the `/v1/admin/api-keys` endpoints exist, but nothing in the web UI reaches them. Today an admin can only mint a key with a hand-rolled `curl` or a browser-console `fetch`. This adds an `/admin/api-keys` page so admins can list, create, and revoke keys from the portal.
+
+No backend changes. The endpoints in `internal/shared_kernel/httpapi/api_key_controller.go` are used exactly as they are.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Route | `/admin/api-keys`, alongside the other admin routes in `App.jsx` |
+| Reveal UX | Blocking modal after creation, dismissible only via an explicit button |
+| Network layer | Extracted to `web/src/utils/apiKeys.js` so it is unit-testable without a DOM |
+| Testing | Vitest unit tests against the utils module; no new test dependencies |
+| Component pattern | Copied from `AdminUsers.jsx` — same header, overlay form, table, and notification usage |
+
+## 1. API contract in use
+
+Already implemented server-side; no changes.
+
+| Method | Path | Notes |
+|---|---|---|
+| `GET` | `/v1/admin/api-keys` | Returns `[{id, name, key_prefix, created_at}]` |
+| `POST` | `/v1/admin/api-keys` | Body `{name}`. `201` returns `{id, name, key, key_prefix, created_at}` — `key` is the plaintext, returned exactly once. `409` duplicate name, `400` missing name |
+| `DELETE` | `/v1/admin/api-keys/{id}` | `204` on success, `404` unknown id. Hard-deletes the row and evicts the cache entry, so revocation is immediate |
+
+All three sit behind `adminPathPrefix` in `internal/infra/httpserver/auth.go`, which requires an admin **session cookie** and explicitly rejects bearer-API-key auth. The page therefore works only for a signed-in admin — the same audience as every other `/admin/*` route — and the browser sends the cookie automatically.
+
+## 2. Network module — `web/src/utils/apiKeys.js`
+
+Three functions wrapping `fetch`, each mapping HTTP status onto a typed error so the component never inspects status codes:
+
+```js
+export class ApiKeyError extends Error {  // carries a `code` field
+  constructor(code, message) { ... }
+}
+
+listAPIKeys()          // GET    → APIKeyResponse[]
+createAPIKey(name)     // POST   → {id, name, key, key_prefix, created_at}
+revokeAPIKey(id)       // DELETE → void
+```
+
+Error codes: `duplicate_name` (409), `name_required` (400), `not_found` (404), `request_failed` (any other non-2xx or network failure). The component maps codes to user-facing copy.
+
+This split exists so the logic is testable: `web/` has vitest but no jsdom or testing-library, and the two existing suites (`src/utils/sw.test.js`, `src/utils/webPush.test.js`) are plain util tests. Keeping `fetch` out of the component preserves that and avoids adding `@testing-library/react` + `jsdom` for a single page.
+
+## 3. Page component — `web/src/components/admin/AdminApiKeys.jsx`
+
+Structure mirrors `AdminUsers.jsx`: `admin-header` with a back-link to `/admin`, a `Key` lucide icon and title, an `admin-actions` bar with a **New API Key** button, and a table.
+
+- **Table** — Name / Key Prefix (monospace) / Created / actions. Empty state: "No API keys yet". Loading state: "Loading API keys…".
+- **Create** — the existing `form-overlay` + `form-card` pattern with one required `name` field. Submit disables the button while in flight.
+- **Reveal modal** — on `201`, the create form is replaced by a blocking modal: warning that this is the only time the key is shown, the full key in a monospace read-only field, a **Copy** button, the key's name, and a single **I've saved it — close** button. No backdrop-click dismissal, no Esc handler. Copy uses `navigator.clipboard.writeText`, falling back to a hidden textarea plus `document.execCommand('copy')` for non-secure contexts (the portal is served over plain HTTP in local development). Closing the modal clears the plaintext from component state and refetches the list.
+- **Revoke** — `window.confirm("Revoke <name>? Any client using it will immediately start getting 401s.")`, then `DELETE`, then refetch. Same shape as `handleDelete` in `AdminUsers.jsx`.
+- **Feedback** — `useNotification()`'s `showSuccess`/`showError`, matching the other admin pages.
+
+## 4. Wiring
+
+- `web/src/App.jsx` — add `<Route path="/admin/api-keys" element={<AdminApiKeys />} />` to the admin block.
+- `web/src/components/admin/AdminDashboard.jsx` — add an "API Keys" quick action (`Key` icon, `teal`) pointing at the new route.
+- `web/src/components/admin/AdminDashboard.css` — define `.action-card.teal` and its `.action-icon` rule. Also define the missing `.action-card.purple` pair: the existing User Access card already passes `color: 'purple'`, but only `.stat-card.purple` was ever written, so that card renders unstyled today. Fixing it is a one-rule change in a file this work already touches.
+
+## 5. Testing
+
+`web/src/utils/apiKeys.test.js`, written before the module, with `global.fetch` stubbed via `vi.fn()`:
+
+- `listAPIKeys` returns the parsed array and requests `/v1/admin/api-keys`.
+- `createAPIKey` posts `{name}` with a JSON content-type and returns the parsed body including `key`.
+- `createAPIKey` throws `ApiKeyError` with code `duplicate_name` on 409 and `name_required` on 400.
+- `revokeAPIKey` issues `DELETE /v1/admin/api-keys/{id}` and throws code `not_found` on 404.
+- A network rejection surfaces as code `request_failed`.
+
+These run under the existing `just unit`, which already invokes `pnpm test` in `web/` via the `_web-test` recipe.
+
+Manual verification: `just build`, sign in as an admin, create a key, confirm the modal shows the plaintext and Copy works, reload to confirm the key is listed by prefix only, then revoke it.
+
+## Deliberately excluded
+
+- **`created_by` and `last_used_at` columns.** Neither is in `APIKeyResponse`; `LastUsedAt` was explicitly excluded from the domain model in the auth design. Surfacing either means a backend change and is out of scope here.
+- **Editing a key's name.** No `PUT` endpoint exists; revoke-and-recreate is the intended flow for a key.
+- **Component-level DOM tests.** Would require `@testing-library/react` and `jsdom`; the utils split covers the logic that can actually break.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -23,6 +23,7 @@ import AdminScheduledTasks from './components/admin/AdminScheduledTasks'
 import AdminTaskExecutions from './components/admin/AdminTaskExecutions'
 import AdminCommands from './components/admin/AdminCommands'
 import AdminHealth from './components/admin/AdminHealth'
+import AdminApiKeys from './components/admin/AdminApiKeys'
 import { NotificationProvider } from './components/NotificationSystem'
 import './App.css'
 
@@ -121,6 +122,7 @@ function AppContent() {
             <Route path="/admin/commands" element={<AdminCommands />} />
             <Route path="/admin/health" element={<AdminHealth />} />
             <Route path="/admin/users" element={<AdminUsers />} />
+            <Route path="/admin/api-keys" element={<AdminApiKeys />} />
           </Routes>
         </main>
       </div>

--- a/web/src/components/admin/AdminApiKeys.css
+++ b/web/src/components/admin/AdminApiKeys.css
@@ -1,0 +1,316 @@
+.admin-api-keys {
+    padding: 2rem;
+    max-width: 100%;
+    margin: 0 auto;
+    background: var(--background);
+    min-height: 100vh;
+}
+
+.admin-api-keys .admin-header {
+    margin-bottom: 2rem;
+}
+
+.admin-api-keys .header-top {
+    margin-bottom: 1rem;
+}
+
+.admin-api-keys .back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.2s ease;
+}
+
+.admin-api-keys .back-link:hover {
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+.admin-api-keys .admin-title {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.admin-api-keys .admin-title h1 {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.admin-api-keys .admin-subtitle {
+    font-size: 1.1rem;
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.admin-api-keys .loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 200px;
+    font-size: 1.1rem;
+    color: var(--text-secondary);
+}
+
+.admin-api-keys .admin-actions {
+    margin-bottom: 2rem;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.admin-api-keys .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-decoration: none;
+}
+
+.admin-api-keys .btn-primary {
+    background: var(--primary);
+    color: white;
+}
+
+.admin-api-keys .btn-primary:hover {
+    background: var(--primary-hover);
+    transform: translateY(-1px);
+}
+
+.admin-api-keys .btn-secondary {
+    background: var(--background-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+}
+
+.admin-api-keys .btn-secondary:hover {
+    background: var(--border);
+}
+
+.admin-api-keys .btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.admin-api-keys .btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background: var(--background-secondary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-decoration: none;
+}
+
+.admin-api-keys .btn-icon:hover {
+    background: var(--border);
+    color: var(--text-primary);
+}
+
+.admin-api-keys .btn-icon.danger:hover {
+    background: #fee2e2;
+    color: #dc2626;
+}
+
+.admin-api-keys .form-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.admin-api-keys .form-card {
+    background: var(--background);
+    border-radius: 12px;
+    padding: 2rem;
+    width: 100%;
+    max-width: 420px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+}
+
+.admin-api-keys .form-card h2 {
+    margin: 0 0 1.5rem 0;
+    color: var(--text-primary);
+}
+
+.admin-api-keys .form-group {
+    margin-bottom: 1.25rem;
+}
+
+.admin-api-keys .form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.admin-api-keys .form-group input[type="text"] {
+    width: 100%;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--background);
+    color: var(--text-primary);
+    font-size: 0.95rem;
+}
+
+.admin-api-keys .form-hint {
+    margin: 0.5rem 0 0 0;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.admin-api-keys .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.admin-api-keys .reveal-card {
+    max-width: 560px;
+}
+
+.admin-api-keys .reveal-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: #b45309;
+    margin-bottom: 1rem;
+}
+
+.admin-api-keys .reveal-title h2 {
+    margin: 0;
+    font-size: 1.35rem;
+    color: var(--text-primary);
+}
+
+.admin-api-keys .reveal-warning {
+    margin: 0 0 1.25rem 0;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    background: #fef3c7;
+    color: #92400e;
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.admin-api-keys .reveal-key {
+    display: flex;
+    gap: 0.75rem;
+    align-items: stretch;
+}
+
+.admin-api-keys .reveal-key input {
+    flex: 1;
+    min-width: 0;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--background-secondary);
+    color: var(--text-primary);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+}
+
+.admin-api-keys .reveal-key .btn {
+    white-space: nowrap;
+}
+
+.admin-api-keys .reveal-meta {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem 1rem;
+    margin: 1.25rem 0 0 0;
+    font-size: 0.9rem;
+}
+
+.admin-api-keys .reveal-meta dt {
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.admin-api-keys .reveal-meta dd {
+    margin: 0;
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+}
+
+.admin-api-keys .reveal-meta code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+}
+
+.api-keys-table-wrapper {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--background);
+}
+
+.api-keys-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.api-keys-table th,
+.api-keys-table td {
+    text-align: left;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-primary);
+}
+
+.api-keys-table th {
+    background: var(--background-secondary);
+    color: var(--text-secondary);
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.api-keys-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.api-keys-table .key-prefix {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.api-key-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.api-keys-table .empty-state {
+    text-align: center;
+    color: var(--text-secondary);
+    padding: 2rem;
+}

--- a/web/src/components/admin/AdminApiKeys.jsx
+++ b/web/src/components/admin/AdminApiKeys.jsx
@@ -1,0 +1,253 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { KeyRound, Plus, Trash2, ArrowLeft, AlertTriangle, Copy, Check } from 'lucide-react'
+import { useNotification } from '../../hooks/useNotification'
+import { createAPIKey, listAPIKeys, revokeAPIKey } from '../../utils/apiKeys'
+import './AdminApiKeys.css'
+
+const createErrorMessages = {
+    duplicate_name: 'An API key with that name already exists',
+    name_required: 'Name is required',
+}
+
+const AdminApiKeys = () => {
+    const { showSuccess, showError } = useNotification()
+    const [apiKeys, setApiKeys] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [showCreateForm, setShowCreateForm] = useState(false)
+    const [creating, setCreating] = useState(false)
+    const [name, setName] = useState('')
+    const [createdKey, setCreatedKey] = useState(null)
+    const [copied, setCopied] = useState(false)
+
+    useEffect(() => {
+        fetchApiKeys()
+    }, [])
+
+    const fetchApiKeys = async () => {
+        try {
+            setLoading(true)
+            setApiKeys(await listAPIKeys())
+        } catch (error) {
+            console.error('Failed to fetch api keys:', error)
+            showError('Failed to load API keys', 'Error')
+            setApiKeys([])
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    const handleCreate = async (event) => {
+        event.preventDefault()
+        try {
+            setCreating(true)
+            const created = await createAPIKey(name.trim())
+            setShowCreateForm(false)
+            setName('')
+            setCreatedKey(created)
+        } catch (error) {
+            console.error('Failed to create api key:', error)
+            showError(createErrorMessages[error.code] || 'Failed to create API key', 'Error')
+        } finally {
+            setCreating(false)
+        }
+    }
+
+    const handleCopy = async () => {
+        try {
+            await copyToClipboard(createdKey.key)
+            setCopied(true)
+        } catch (error) {
+            console.error('Failed to copy api key:', error)
+            showError('Failed to copy — select the key and copy it manually', 'Error')
+        }
+    }
+
+    const handleAcknowledge = () => {
+        setCreatedKey(null)
+        setCopied(false)
+        showSuccess('API key created', 'Success')
+        fetchApiKeys()
+    }
+
+    const handleRevoke = async (apiKey) => {
+        if (!window.confirm(`Revoke "${apiKey.name}"? Any client using it will immediately start getting 401s.`)) {
+            return
+        }
+
+        try {
+            await revokeAPIKey(apiKey.id)
+            showSuccess('API key revoked', 'Success')
+            fetchApiKeys()
+        } catch (error) {
+            console.error('Failed to revoke api key:', error)
+            showError('Failed to revoke API key', 'Error')
+        }
+    }
+
+    const formatCreatedAt = (value) => {
+        if (!value) return '—'
+        return new Date(value).toLocaleString()
+    }
+
+    return (
+        <div className="admin-api-keys">
+            <div className="admin-header">
+                <div className="header-top">
+                    <Link to="/admin" className="back-link">
+                        <ArrowLeft size={16} />
+                        Back to Dashboard
+                    </Link>
+                </div>
+                <div className="admin-title">
+                    <KeyRound size={32} />
+                    <h1>API Keys</h1>
+                </div>
+                <p className="admin-subtitle">Grant non-human clients access to the API</p>
+            </div>
+
+            <div className="admin-actions">
+                <button className="btn btn-primary" onClick={() => setShowCreateForm(true)}>
+                    <Plus size={16} />
+                    New API Key
+                </button>
+            </div>
+
+            {showCreateForm && (
+                <div className="form-overlay">
+                    <div className="form-card">
+                        <h2>Create API Key</h2>
+                        <form onSubmit={handleCreate}>
+                            <div className="form-group">
+                                <label htmlFor="name">Name</label>
+                                <input
+                                    id="name"
+                                    type="text"
+                                    required
+                                    autoFocus
+                                    placeholder="grafana-sync"
+                                    value={name}
+                                    onChange={(e) => setName(e.target.value)}
+                                />
+                                <p className="form-hint">A label to identify this key later. It cannot be changed.</p>
+                            </div>
+                            <div className="form-actions">
+                                <button
+                                    type="button"
+                                    className="btn btn-secondary"
+                                    onClick={() => setShowCreateForm(false)}
+                                    disabled={creating}
+                                >
+                                    Cancel
+                                </button>
+                                <button type="submit" className="btn btn-primary" disabled={creating}>
+                                    {creating ? 'Creating...' : 'Create Key'}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
+
+            {createdKey && (
+                <div className="form-overlay">
+                    <div className="form-card reveal-card">
+                        <div className="reveal-title">
+                            <AlertTriangle size={20} />
+                            <h2>Copy your API key now</h2>
+                        </div>
+                        <p className="reveal-warning">
+                            This is the only time it will be shown. Once you close this dialog it cannot be
+                            retrieved — you would have to create a new key.
+                        </p>
+                        <div className="reveal-key">
+                            <input type="text" readOnly value={createdKey.key} onFocus={(e) => e.target.select()} />
+                            <button type="button" className="btn btn-secondary" onClick={handleCopy}>
+                                {copied ? <Check size={16} /> : <Copy size={16} />}
+                                {copied ? 'Copied' : 'Copy'}
+                            </button>
+                        </div>
+                        <dl className="reveal-meta">
+                            <dt>Name</dt>
+                            <dd>{createdKey.name}</dd>
+                            <dt>Usage</dt>
+                            <dd><code>Authorization: Bearer &lt;key&gt;</code></dd>
+                        </dl>
+                        <div className="form-actions">
+                            <button type="button" className="btn btn-primary" onClick={handleAcknowledge}>
+                                I&apos;ve saved it — close
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {loading ? (
+                <div className="loading">Loading API keys...</div>
+            ) : (
+                <div className="api-keys-table-wrapper">
+                    <table className="api-keys-table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Key Prefix</th>
+                                <th>Created</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {apiKeys.map((apiKey) => (
+                                <tr key={apiKey.id}>
+                                    <td>{apiKey.name}</td>
+                                    <td><code className="key-prefix">{apiKey.key_prefix}…</code></td>
+                                    <td>{formatCreatedAt(apiKey.created_at)}</td>
+                                    <td>
+                                        <div className="api-key-actions">
+                                            <button
+                                                className="btn-icon danger"
+                                                onClick={() => handleRevoke(apiKey)}
+                                                title="Revoke key"
+                                            >
+                                                <Trash2 size={16} />
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))}
+                            {apiKeys.length === 0 && (
+                                <tr>
+                                    <td colSpan="4" className="empty-state">No API keys yet</td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    )
+}
+
+async function copyToClipboard(value) {
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value)
+        return
+    }
+
+    const textarea = document.createElement('textarea')
+    textarea.value = value
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'absolute'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+    textarea.select()
+
+    try {
+        if (!document.execCommand('copy')) {
+            throw new Error('copy command was rejected')
+        }
+    } finally {
+        document.body.removeChild(textarea)
+    }
+}
+
+export default AdminApiKeys

--- a/web/src/components/admin/AdminDashboard.css
+++ b/web/src/components/admin/AdminDashboard.css
@@ -236,6 +236,14 @@
     border-left: 4px solid #f59e0b;
 }
 
+.action-card.purple {
+    border-left: 4px solid #8b5cf6;
+}
+
+.action-card.teal {
+    border-left: 4px solid #14b8a6;
+}
+
 .action-icon {
     width: 48px;
     height: 48px;
@@ -259,6 +267,16 @@
 .action-card.orange .action-icon {
     background: rgba(245, 158, 11, 0.1);
     color: #f59e0b;
+}
+
+.action-card.purple .action-icon {
+    background: rgba(139, 92, 246, 0.1);
+    color: #8b5cf6;
+}
+
+.action-card.teal .action-icon {
+    background: rgba(20, 184, 166, 0.1);
+    color: #14b8a6;
 }
 
 .action-content h3 {

--- a/web/src/components/admin/AdminDashboard.jsx
+++ b/web/src/components/admin/AdminDashboard.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { Building, Cpu, Play, Shield, Activity, Users, Database, RefreshCw } from 'lucide-react'
+import { Building, Cpu, Play, Shield, Activity, Users, Database, RefreshCw, KeyRound } from 'lucide-react'
 import { useNotification } from '../../hooks/useNotification'
 import './AdminDashboard.css'
 
@@ -81,6 +81,13 @@ const AdminDashboard = () => {
             icon: Users,
             link: '/admin/users',
             color: 'purple'
+        },
+        {
+            title: 'API Keys',
+            description: 'Issue and revoke keys for non-human clients',
+            icon: KeyRound,
+            link: '/admin/api-keys',
+            color: 'teal'
         }
     ]
 

--- a/web/src/utils/apiKeys.js
+++ b/web/src/utils/apiKeys.js
@@ -1,0 +1,53 @@
+const BASE_PATH = '/v1/admin/api-keys'
+
+const STATUS_CODES = {
+    400: 'name_required',
+    404: 'not_found',
+    409: 'duplicate_name',
+}
+
+export class ApiKeyError extends Error {
+    constructor(code, message) {
+        super(message)
+        this.name = 'ApiKeyError'
+        this.code = code
+    }
+}
+
+function errorForStatus(status) {
+    const code = STATUS_CODES[status] || 'request_failed'
+    return new ApiKeyError(code, `api key request failed with status ${status}`)
+}
+
+async function request(url, ...options) {
+    let response
+    try {
+        response = await fetch(url, ...options)
+    } catch (error) {
+        throw new ApiKeyError('request_failed', `api key request failed: ${error.message}`)
+    }
+
+    if (!response.ok) {
+        throw errorForStatus(response.status)
+    }
+
+    return response
+}
+
+export async function listAPIKeys() {
+    const response = await request(BASE_PATH)
+    return response.json()
+}
+
+export async function createAPIKey(name) {
+    const response = await request(BASE_PATH, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+    })
+    return response.json()
+}
+
+export async function revokeAPIKey(id) {
+    await request(`${BASE_PATH}/${id}`, { method: 'DELETE' })
+}

--- a/web/src/utils/apiKeys.test.js
+++ b/web/src/utils/apiKeys.test.js
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiKeyError, createAPIKey, listAPIKeys, revokeAPIKey } from './apiKeys'
+
+function stubFetch(response) {
+    const fetch = vi.fn().mockResolvedValue(response)
+    vi.stubGlobal('fetch', fetch)
+    return fetch
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+describe('listAPIKeys', () => {
+    it('returns the keys from the admin endpoint', async () => {
+        const keys = [{ id: 'key-1', name: 'grafana', key_prefix: 'zsk_ab12cd34', created_at: '2026-08-05T10:00:00Z' }]
+        const fetch = stubFetch({ ok: true, status: 200, json: async () => keys })
+
+        const result = await listAPIKeys()
+
+        expect(fetch).toHaveBeenCalledWith('/v1/admin/api-keys')
+        expect(result).toEqual(keys)
+    })
+
+    it('fails with request_failed when the server errors', async () => {
+        stubFetch({ ok: false, status: 500 })
+
+        await expect(listAPIKeys()).rejects.toMatchObject({ code: 'request_failed' })
+    })
+})
+
+describe('createAPIKey', () => {
+    it('posts the name and returns the created key with its plaintext', async () => {
+        const created = {
+            id: 'key-1',
+            name: 'grafana',
+            key: 'zsk_ab12cd34ef56',
+            key_prefix: 'zsk_ab12cd34',
+            created_at: '2026-08-05T10:00:00Z',
+        }
+        const fetch = stubFetch({ ok: true, status: 201, json: async () => created })
+
+        const result = await createAPIKey('grafana')
+
+        expect(fetch).toHaveBeenCalledWith('/v1/admin/api-keys', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'grafana' }),
+        })
+        expect(result).toEqual(created)
+    })
+
+    it('fails with duplicate_name when the name is already taken', async () => {
+        stubFetch({ ok: false, status: 409 })
+
+        await expect(createAPIKey('grafana')).rejects.toMatchObject({ code: 'duplicate_name' })
+    })
+
+    it('fails with name_required when the server rejects the name', async () => {
+        stubFetch({ ok: false, status: 400 })
+
+        await expect(createAPIKey('')).rejects.toMatchObject({ code: 'name_required' })
+    })
+
+    it('fails with request_failed when the network is unreachable', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+
+        await expect(createAPIKey('grafana')).rejects.toMatchObject({ code: 'request_failed' })
+    })
+})
+
+describe('revokeAPIKey', () => {
+    it('deletes the key by id', async () => {
+        const fetch = stubFetch({ ok: true, status: 204 })
+
+        await revokeAPIKey('key-1')
+
+        expect(fetch).toHaveBeenCalledWith('/v1/admin/api-keys/key-1', { method: 'DELETE' })
+    })
+
+    it('fails with not_found when the key no longer exists', async () => {
+        stubFetch({ ok: false, status: 404 })
+
+        await expect(revokeAPIKey('key-1')).rejects.toMatchObject({ code: 'not_found' })
+    })
+})
+
+describe('ApiKeyError', () => {
+    it('is thrown for failed requests so callers can branch on the code', async () => {
+        stubFetch({ ok: false, status: 409 })
+
+        await expect(createAPIKey('grafana')).rejects.toBeInstanceOf(ApiKeyError)
+    })
+})


### PR DESCRIPTION
## Summary

The API key endpoints ([#40](https://github.com/zensor-iot/zensor-server/pull/40)) shipped backend-only — `/v1/admin/api-keys` existed but nothing in the portal reached it, so minting a key meant hand-rolling a `curl` or a browser-console `fetch`. This adds `/admin/api-keys` to list, create, and revoke keys.

No backend changes; the existing endpoints are used as-is.

## What's included

- `web/src/utils/apiKeys.js` — `listAPIKeys` / `createAPIKey` / `revokeAPIKey`, mapping HTTP status onto typed `ApiKeyError` codes (`duplicate_name`, `name_required`, `not_found`, `request_failed`)
- `web/src/components/admin/AdminApiKeys.jsx` + `.css` — the page, following `AdminUsers.jsx`
- Route in `App.jsx`, quick-action card in `AdminDashboard.jsx`

The plaintext key is returned exactly once, so creation opens a **blocking modal** with a copy button that only closes via an explicit "I've saved it" — no backdrop-click, no Esc. Copy falls back to `document.execCommand` outside secure contexts.

Also defines `.action-card.purple`, which the User Access card has referenced since it was added — only `.stat-card.purple` was ever written, so that card rendered without its accent.

## Testing

Network logic is unit tested (7 tests) rather than the component: `web/` has vitest but no jsdom or testing-library, and the existing suites are plain util tests. Keeping `fetch` out of the component avoids pulling in `@testing-library/react` + `jsdom` for one page.

Beyond the automated tests, every path was exercised in a browser against a mock API — list render, create → reveal modal → copy → close → refresh, revoke, and the 409 duplicate-name error (form stays open to correct the name).

- `just unit` — web tests + all 29 Go suites pass
- `just build` — passes
- 0 new lint errors (repo-wide `pnpm lint` still fails on 42 pre-existing errors elsewhere)

## Notes for reviewers

- **The page requires an auth-enabled deployment.** When `auth.enabled` is false, `cmd/api/main.go:95-104` never registers the API key controller, so the endpoints 404. Existing behavior, but it means `ENV=local` alone isn't enough to try this.
- **No `created_by` / `last_used_at` columns.** Neither is in `APIKeyResponse`, and `LastUsedAt` was deliberately excluded from the domain model in the auth design. Surfacing either needs a backend change — out of scope here.

Design spec: `docs/superpowers/specs/2026-08-05-admin-api-keys-page-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)